### PR TITLE
Update gen_kpp.c

### DIFF
--- a/chem/KPP/util/wkc/gen_kpp.c
+++ b/chem/KPP/util/wkc/gen_kpp.c
@@ -25,7 +25,7 @@
   55020 Mainz, Germany
   e-mail: salzmann@mpch-mainz.mpg.de
   www.mpch-mainz.mpg.de/~salzmann/my_home/index.html
-
+  there used to be a bug of sequence ,now is solved by xiya liu on 2023
 .....................................................................
 
  assumed directory name in KPP corresponds to WRF package name
@@ -60,101 +60,6 @@
 
 /*    cd chem/KPP/util/wkc; make -i -r CC="gcc" ; cd ../../../..
   in ~WRF:  chem/KPP/util/wkc/registry_kpp Registry/Registry          */
-
-
-int
-gen_kpp ( char * inc_dirname, char * kpp_dirname )
-{
-
-
-
-  /* put chem compound names defined in Registry into linked list WRFC_packs */
-
-       if ( DEBUGR == 1 )   printf("next: get_wrf_chem_specs \n");
-     get_wrf_chem_specs () ;
-       if ( DEBUGR == 2 ) write_list_to_screen( WRFC_packs ) ;
-   
-      
-       
-
-  /* put radical names defined in Registry into linked list WRFC_radicals */
-
-       if ( DEBUGR == 1 )   printf("next: get_wrf_radicals \n");
-     get_wrf_radicals () ;
-       if ( DEBUGR == 2 ) write_list_to_screen( WRFC_radicals ) ;
-
-
-  /* put photolysis rates defined in Registry into linked list WRFC_jvals */
-
-       if ( DEBUGR == 1 )   printf("next: get_wrf_jvals \n");
-     get_wrf_jvals () ;
-       if ( DEBUGR == 2 ) write_list_to_screen( WRFC_jvals ) ;
-
-
-  /* read KPP species files and put compound names into linked list KPP_packs */     
-       if ( DEBUGR == 1 )   printf("next: get_kpp_chem_specs \n");     
-     get_kpp_chem_specs ( kpp_dirname ) ; 
-       if ( DEBUGR == 2 ) {write_list_to_screen( KPP_packs ) ;} 
-
-
-
-    
-
-  /* define pointer from each KPP package to corresponding WRF-Chem chemistry package  and check whether variable names are consistent. If *_wrfkpp.equiv file exists in KPP directory use it for name matching */
- 
-
-       if ( DEBUGR == 1 )   printf("next: compare_kpp_to_species \n"); 
-     compare_kpp_to_species ( kpp_dirname );
-
-
-
-    
- 
-     /* write some output to screen  */
-       if ( DEBUGR == 1 )   printf("next: screen_out \n");
-     screen_out( );
-
-
-     /* make sure that wrf and kpp variables match and stop if not.  */
-      if ( DEBUGR == 1 )   printf("next: check_all \n");
-     check_all ( kpp_dirname );
-
-    
-
-     /* add the kpp generated modules to the Makefile in the chem directory */        
-           if ( DEBUGR == 1 )   printf("next: change_chem_Makefile  \n");
-	     change_chem_Makefile ( ); 
-
-     
-
-
-  /* write the mechanism driver */
-      if ( DEBUGR == 1 )   printf("next: gen_kpp_mechanism_driver (writing chem/kpp_mechanism_driver.F) \n");
-     gen_kpp_mechanism_driver ( );
-
-
-      if ( DEBUGR == 1 )   printf("next: gen_call_to_kpp_mechanism_driver (writing inc/call_to_kpp_mech_drive.inc) \n");
-     gen_kpp_call_to_mech_dr ( );
-
-
-     /* write arguments for call to KPPs Update_Rconst      */
-          if ( DEBUGR == 1 )   printf("next: gen_kpp_args_to_Update_Rconst (writing inc/args_to_update_rconst.inc and inc/<decls_update_rconst.inc) \n");
-     gen_kpp_args_to_Update_Rconst ( );
-     
-
-    /* write the interface */
-      if ( DEBUGR == 1 )   printf("next: gen_kpp_interface (writing several module_kpp_* for each mechanism)\n");
-     gen_kpp_interface ( );
-     
-
-    
-      if ( DEBUGR == 1 )   printf("DONE gen_kpp \n");
-
-  return(0) ;
-}
-
-
-
 
 /*---------------------------------------------------------------------*/
 int
@@ -257,3 +162,99 @@ knode_t * p1, * p2, * pm1;
      }
    }
 }
+
+int
+gen_kpp ( char * inc_dirname, char * kpp_dirname )
+{
+
+
+
+  /* put chem compound names defined in Registry into linked list WRFC_packs */
+
+       if ( DEBUGR == 1 )   printf("next: get_wrf_chem_specs \n");
+     get_wrf_chem_specs () ;
+       if ( DEBUGR == 2 ) write_list_to_screen( WRFC_packs ) ;
+   
+      
+       
+
+  /* put radical names defined in Registry into linked list WRFC_radicals */
+
+       if ( DEBUGR == 1 )   printf("next: get_wrf_radicals \n");
+     get_wrf_radicals () ;
+       if ( DEBUGR == 2 ) write_list_to_screen( WRFC_radicals ) ;
+
+
+  /* put photolysis rates defined in Registry into linked list WRFC_jvals */
+
+       if ( DEBUGR == 1 )   printf("next: get_wrf_jvals \n");
+     get_wrf_jvals () ;
+       if ( DEBUGR == 2 ) write_list_to_screen( WRFC_jvals ) ;
+
+
+  /* read KPP species files and put compound names into linked list KPP_packs */     
+       if ( DEBUGR == 1 )   printf("next: get_kpp_chem_specs \n");     
+     get_kpp_chem_specs ( kpp_dirname ) ; 
+       if ( DEBUGR == 2 ) {write_list_to_screen( KPP_packs ) ;} 
+
+
+
+    
+
+  /* define pointer from each KPP package to corresponding WRF-Chem chemistry package  and check whether variable names are consistent. If *_wrfkpp.equiv file exists in KPP directory use it for name matching */
+ 
+
+       if ( DEBUGR == 1 )   printf("next: compare_kpp_to_species \n"); 
+     compare_kpp_to_species ( kpp_dirname );
+
+
+
+    
+ 
+     /* write some output to screen  */
+       if ( DEBUGR == 1 )   printf("next: screen_out \n");
+     screen_out( );
+
+
+     /* make sure that wrf and kpp variables match and stop if not.  */
+      if ( DEBUGR == 1 )   printf("next: check_all \n");
+     check_all ( kpp_dirname );
+
+    
+
+     /* add the kpp generated modules to the Makefile in the chem directory */        
+           if ( DEBUGR == 1 )   printf("next: change_chem_Makefile  \n");
+	     change_chem_Makefile ( ); 
+
+     
+
+
+  /* write the mechanism driver */
+      if ( DEBUGR == 1 )   printf("next: gen_kpp_mechanism_driver (writing chem/kpp_mechanism_driver.F) \n");
+     gen_kpp_mechanism_driver ( );
+
+
+      if ( DEBUGR == 1 )   printf("next: gen_call_to_kpp_mechanism_driver (writing inc/call_to_kpp_mech_drive.inc) \n");
+     gen_kpp_call_to_mech_dr ( );
+
+
+     /* write arguments for call to KPPs Update_Rconst      */
+          if ( DEBUGR == 1 )   printf("next: gen_kpp_args_to_Update_Rconst (writing inc/args_to_update_rconst.inc and inc/<decls_update_rconst.inc) \n");
+     gen_kpp_args_to_Update_Rconst ( );
+     
+
+    /* write the interface */
+      if ( DEBUGR == 1 )   printf("next: gen_kpp_interface (writing several module_kpp_* for each mechanism)\n");
+     gen_kpp_interface ( );
+     
+
+    
+      if ( DEBUGR == 1 )   printf("DONE gen_kpp \n");
+
+  return(0) ;
+}
+
+
+
+
+


### PR DESCRIPTION
there is a mistake in official file gen_kpp.c, their gen_kpp.c 's function definition order is reserved! So when you make there is a report of error:implicit function: write_list_to_screen,screen_out,check_all 官方很多WRF版本的chem下面的/chem/KPP/util/wkc/gen_kpp.c都是错的（直到2023.4.27最新版的WRF里面的这个都还是错的），因为他把函数顺序给放反了，把write_list_to_screen跟screen_out还有check_all都放在最下面了，而gen_kpp函数却放在最上面，所以就会导致报错函数没有定义，因此需要将原文件里面的函数顺序换一下，把write_list_to_screen等3个函数放到gen_kpp的上面，在我的这里是已经修改好的gen_kpp.c文件，下载后替换即可

TYPE: bug fix

KEYWORDS: kpp,gen_kpp,/chem/KPP/util/wkc/gen_kpp.c

SOURCE:https://github.com/vergillovedante  this is my homepage on github email is vergillovedante@outlook.com

DESCRIPTION OF CHANGES:
Problem:one of the the file's  of kpp's functions' sequence is wrong


Solution:replace gen_kpp.c with my uploaded file


ISSUE: Fixes:001 -provided by lxy(vergillovedante)



RELEASE NOTE: Include a stand-alone message suitable for the inclusion in the minor and annual releases. A publication citation is appropriate.

The first line should be a single-line "purpose" for this change

TYPE: choose one of [bug fix, enhancement, new feature, feature removed, no impact, text only]

KEYWORDS: 5 to 10 words related to commit, separated by commas

SOURCE: Either "developer's name (affiliation)" .XOR. "internal" for a WRF Dev committee member

DESCRIPTION OF CHANGES:
Problem:
Generally or specifically, what was wrong and needed to be addressed?

Solution:
What was down algorithmically and in the source code to address the problem?

ISSUE: For use when this PR closes an issue.
Fixes #123

LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)

TESTS CONDUCTED: 
1. Do mods fix problem? How can that be demonstrated, and was that test conducted?
2. Are the Jenkins tests all passing?

RELEASE NOTE: Include a stand-alone message suitable for the inclusion in the minor and annual releases. A publication citation is appropriate.
